### PR TITLE
log request data as JSON lines

### DIFF
--- a/lib/get-repo.js
+++ b/lib/get-repo.js
@@ -1,0 +1,7 @@
+const obj2map = obj => Object.keys(obj).reduce((m, k) => m.set(k, obj[k]), new Map())
+const repos = obj2map(require('all-the-package-repos'))
+delete require.cache[require.resolve('all-the-package-repos')]
+
+module.exports = function getRepo (name) {
+  return repos.get(name) || `https://npmjs.com/package/${name}`
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,18 @@
+const env = require('lil-env-thing')
+const cleanDeep = require('clean-deep')
+
+module.exports = function logger (req, res, next) {
+  // don't pollute test output
+  if (env.test) return next()
+
+  const data = cleanDeep({
+    name: req.params.name,
+    domain: req.domain,
+    ip: req.ip,
+    headers: req.headers
+  })
+
+  console.log(`query: ${JSON.stringify(data)}`)
+
+  return next()
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,9 +2,6 @@ const env = require('lil-env-thing')
 const cleanDeep = require('clean-deep')
 
 module.exports = function logger (req, res, next) {
-  // don't pollute test output
-  if (env.test) return next()
-
   const data = cleanDeep({
     name: req.params.name,
     domain: req.domain,
@@ -12,7 +9,10 @@ module.exports = function logger (req, res, next) {
     headers: req.headers
   })
 
-  console.log(`query: ${JSON.stringify(data)}`)
+  // don't pollute test output
+  if (!env.test) {
+    console.log(`query: ${JSON.stringify(data)}`)
+  }
 
   return next()
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "all-the-package-repos": "^1.2.1",
+    "clean-deep": "^3.0.2",
     "express": "^4.16.2",
     "lil-env-thing": "^1.0.0"
   },

--- a/server.js
+++ b/server.js
@@ -1,25 +1,17 @@
 const express = require('express')
 const port = Number(process.env.PORT) || 5000
-const obj2map = obj => Object.keys(obj).reduce((m, k) => m.set(k, obj[k]), new Map())
-const repos = obj2map(require('all-the-package-repos'))
-delete require.cache[require.resolve('all-the-package-repos')]
-const env = require('lil-env-thing')
+const getRepo = require('./lib/get-repo')
+const logger = require('./lib/logger')
 const app = express()
+
+app.use('/:name', logger)
 
 app.get('/', (req, res, next) => {
   res.redirect('https://github.com/nice-registry/package.land#readme')
 })
 
 app.get('/:name', (req, res, next) => {
-  const name = req.params.name
-  const repo = repos.get(name) || `https://npmjs.com/package/${name}`
-  log({
-    pkg: name,
-    ip: req.ip,
-    agent: req.headers['user-agent'],
-    language: req.headers['accept-language']
-  })
-  res.redirect(repo)
+  res.redirect(getRepo(req.params.name))
 })
 
 if (!module.parent) {
@@ -29,7 +21,3 @@ if (!module.parent) {
 }
 
 module.exports = app
-
-function log (obj) {
-  if (!env.test) console.log(JSON.stringify(obj))
-}

--- a/test/server.js
+++ b/test/server.js
@@ -29,7 +29,7 @@ describe('package.land', () => {
     res.headers.location.should.equal('https://npmjs.com/package/__defineGetter__')
   })
 
-  it('should redirect properly if a package with the native function exsists', async () => {
+  it('should redirect properly if a package with the native function exists', async () => {
     const res = await supertest(app).get(`/toString`)
     res.statusCode.should.equal(302)
     res.headers.location.should.equal('https://github.com/uxnow/toString')


### PR DESCRIPTION
This PR adds JSON logging on package name requests. I've set up a Heroku log drain to S3 using this repo: https://github.com/choonkeat/heroku-log-s3 -- all queries will be published to a public S3 bucket.

I also moved `getRepos` into a module in /lib to prepare for using it as a CLI tool in a forthcoming PR.